### PR TITLE
Fix the case when configured URL doesn't have slash or have extra new…

### DIFF
--- a/plugins/iilyak/splitweb/adaptor.js
+++ b/plugins/iilyak/splitweb/adaptor.js
@@ -43,7 +43,7 @@ SplitWebAdaptor.prototype.isReady = function() {
 };
 
 SplitWebAdaptor.prototype.getHost = function() {
-	var text = this.wiki.getTiddlerText(CONFIG_HOST_TIDDLER,DEFAULT_HOST_TIDDLER),
+	var text = this.wiki.getTiddlerText(CONFIG_HOST_TIDDLER,DEFAULT_HOST_TIDDLER).trim(),
 		substitutions = [
 			{name: "protocol", value: document.location.protocol},
 			{name: "host", value: document.location.host}
@@ -52,6 +52,7 @@ SplitWebAdaptor.prototype.getHost = function() {
 		var s = substitutions[t];
 		text = $tw.utils.replaceString(text,new RegExp("\\$" + s.name + "\\$","mg"),s.value);
 	}
+	text += text.endsWith("/") ? "" : "/";
 	return text;
 };
 


### PR DESCRIPTION
I had extra empty lines in the `$:/config/splitweb/host` and had a very hard time trying to debug why it is crashing. Then I removed the extra lines and it was still crashing. I figured that trailing slash is mandatory. This PR makes sure we fix up these common mistakes.